### PR TITLE
feat: populate verifyContext from core.verify.resolve attestation

### DIFF
--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -8,7 +8,7 @@ import {
   isJsonRpcResponse,
   isJsonRpcResult,
 } from "@exodus/walletconnect-jsonrpc-utils";
-import { RelayerTypes, Verify } from "@exodus/walletconnect-types";
+import { RelayerTypes } from "@exodus/walletconnect-types";
 import { getInternalError, hashKey, TYPE_1 } from "@exodus/walletconnect-utils";
 import { AUTH_CLIENT_PUBLIC_KEY_NAME, ENGINE_RPC_OPTS } from "../constants";
 import { AuthClientTypes, AuthEngineTypes, IAuthEngine, JsonRpcTypes } from "../types";
@@ -17,6 +17,7 @@ import { verifySignature } from "../utils/signature";
 import { getPendingRequest, getPendingRequests } from "../utils/store";
 import { isValidRequest, isValidRespond } from "../utils/validators";
 import { hashMessage } from "../utils/crypto";
+import { buildVerifyContext } from "../utils/verifyContext";
 
 export class AuthEngine extends IAuthEngine {
   private initialized = false;
@@ -361,7 +362,7 @@ export class AuthEngine extends IAuthEngine {
       });
 
       const hash = hashMessage(JSON.stringify(payload));
-      const verifyContext = await this.getVerifyContext(hash, this.client.metadata);
+      const verifyContext = await this.getVerifyContext(hash, requester.metadata);
 
       this.client.emit("auth_request", {
         id: payload.id,
@@ -426,15 +427,13 @@ export class AuthEngine extends IAuthEngine {
     }
   };
 
-  private getVerifyContext = async (_hash: string, metadata: AuthClientTypes.Metadata) => {
-    const context: Verify.Context = {
-      verified: {
-        verifyUrl: metadata.verifyUrl || "",
-        validation: "UNKNOWN",
-        origin: metadata.url || "",
+  private getVerifyContext = (hash: string, metadata: AuthClientTypes.Metadata) =>
+    buildVerifyContext(
+      {
+        resolve: (args) => this.client.core.verify.resolve(args),
+        logError: (e) => this.client.logger.error(e),
       },
-    };
-
-    return context;
-  };
+      hash,
+      metadata,
+    );
 }

--- a/packages/auth-client/src/utils/verifyContext.ts
+++ b/packages/auth-client/src/utils/verifyContext.ts
@@ -1,0 +1,74 @@
+import { Verify } from "@exodus/walletconnect-types";
+import { AuthClientTypes } from "../types";
+
+export interface BuildVerifyContextDeps {
+  resolve: (args: {
+    attestationId: string;
+    verifyUrl?: string;
+  }) => Promise<{ origin?: string; isScam?: boolean } | string | undefined>;
+  logError?: (err: unknown) => void;
+}
+
+export const buildVerifyContext = async (
+  { resolve, logError }: BuildVerifyContextDeps,
+  attestationId: string,
+  metadata: AuthClientTypes.Metadata,
+): Promise<Verify.Context> => {
+  if (!metadata?.url) {
+    const context: Verify.Context = {
+      verified: { verifyUrl: "", validation: "UNKNOWN", origin: "" },
+    };
+    try {
+      const attestation = await resolve({ attestationId });
+      if (attestation) {
+        const origin =
+          typeof attestation === "string" ? attestation : (attestation as any).origin;
+        if (origin && typeof origin === "string") {
+          // Registered dApps always declare metadata.url; receiving an attested
+          // origin while the dApp claims nothing is mismatch by definition.
+          context.verified.origin = origin;
+          context.verified.validation = "INVALID";
+        }
+        if (typeof attestation === "object" && (attestation as any).isScam) {
+          context.verified.isScam = true;
+        }
+      }
+    } catch (e) {
+      logError?.(e);
+    }
+    return context;
+  }
+
+  const context: Verify.Context = {
+    verified: {
+      verifyUrl: metadata.verifyUrl || "",
+      validation: "UNKNOWN",
+      origin: metadata.url || "",
+    },
+  };
+
+  try {
+    const attestation = await resolve({
+      attestationId,
+      verifyUrl: metadata.verifyUrl,
+    });
+    if (attestation) {
+      const origin = typeof attestation === "string" ? attestation : (attestation as any).origin;
+      if (origin && typeof origin === "string") {
+        context.verified.origin = origin;
+        let claimedOrigin = metadata.url || "";
+        try {
+          claimedOrigin = new URL(metadata.url).origin;
+        } catch {}
+        context.verified.validation = origin === claimedOrigin ? "VALID" : "INVALID";
+      }
+      if (typeof attestation === "object" && (attestation as any).isScam) {
+        context.verified.isScam = true;
+      }
+    }
+  } catch (e) {
+    logError?.(e);
+  }
+
+  return context;
+};

--- a/packages/auth-client/test/engineVerifyWiring.spec.ts
+++ b/packages/auth-client/test/engineVerifyWiring.spec.ts
@@ -1,0 +1,90 @@
+import { expect, describe, it, vi, beforeEach } from "vitest";
+import { AuthEngine } from "../src/controllers/engine";
+import { AuthClientTypes } from "../src/types";
+
+const WALLET_URL = "https://mywallet.app";
+const DAPP_URL = "https://app.uniswap.org";
+
+const walletMetadata: AuthClientTypes.Metadata = {
+  name: "My Wallet",
+  description: "",
+  url: WALLET_URL,
+  icons: [],
+};
+
+const dappMetadata: AuthClientTypes.Metadata = {
+  name: "Uniswap",
+  description: "",
+  url: DAPP_URL,
+  icons: [],
+};
+
+const authRequestPayload = {
+  id: 1,
+  jsonrpc: "2.0" as const,
+  method: "wc_authRequest" as const,
+  params: {
+    requester: {
+      publicKey: "abc123",
+      metadata: dappMetadata,
+    },
+    payloadParams: {
+      type: "eip4361" as const,
+      chainId: "eip155:1",
+      domain: "app.uniswap.org",
+      aud: "https://app.uniswap.org/login",
+      version: "1",
+      nonce: "deadbeef",
+      iat: new Date().toISOString(),
+    },
+  },
+};
+
+function createMockClient(verifyResolveReturn: unknown) {
+  return {
+    metadata: walletMetadata,
+    logger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    requests: {
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    core: {
+      verify: {
+        resolve: vi.fn().mockResolvedValue(verifyResolveReturn),
+      },
+      pairing: {
+        register: vi.fn(),
+      },
+    },
+    emit: vi.fn(),
+  } as any;
+}
+
+describe("AuthEngine.onAuthRequest verifyContext wiring", () => {
+  it("produces VALID when attested origin matches requester (dApp) URL", async () => {
+    const mockClient = createMockClient({ origin: DAPP_URL });
+    const engine = new AuthEngine(mockClient);
+
+    await (engine as any).onAuthRequest("topic", authRequestPayload);
+
+    const [eventName, eventArgs] = mockClient.emit.mock.calls[0];
+    expect(eventName).toBe("auth_request");
+    expect(eventArgs.verifyContext.verified.validation).toBe("VALID");
+    expect(eventArgs.verifyContext.verified.origin).toBe(DAPP_URL);
+  });
+
+  it("produces INVALID when attested origin matches wallet URL but not requester URL (regression guard)", async () => {
+    const mockClient = createMockClient({ origin: WALLET_URL });
+    const engine = new AuthEngine(mockClient);
+
+    await (engine as any).onAuthRequest("topic", authRequestPayload);
+
+    const [eventName, eventArgs] = mockClient.emit.mock.calls[0];
+    expect(eventName).toBe("auth_request");
+    expect(eventArgs.verifyContext.verified.validation).toBe("INVALID");
+    expect(eventArgs.verifyContext.verified.origin).toBe(WALLET_URL);
+  });
+});

--- a/packages/auth-client/test/verifyContext.spec.ts
+++ b/packages/auth-client/test/verifyContext.spec.ts
@@ -1,0 +1,203 @@
+import { expect, describe, it, vi } from "vitest";
+import { buildVerifyContext } from "../src/utils/verifyContext";
+
+const noopLog = (_err: unknown) => {
+  return;
+};
+
+describe("buildVerifyContext", () => {
+  it("returns UNKNOWN when resolver returns undefined", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      { name: "x", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("returns UNKNOWN when resolver throws", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.reject(new Error("network")),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "x", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+  });
+
+  it("returns VALID when attested origin matches requester metadata.url", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://app.uniswap.org" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("VALID");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("returns INVALID when attested origin differs from claimed metadata.url", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://attacker.com");
+  });
+
+  it("propagates isScam=true from attestation", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com", isScam: true }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.isScam).toBe(true);
+  });
+
+  it("sets isScam for any truthy attestation value (matches upstream)", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () =>
+          Promise.resolve({ origin: "https://x.com", isScam: 1 as unknown as boolean }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "x", description: "", url: "https://x.com", icons: [] },
+    );
+    expect(ctx.verified.isScam).toBe(true);
+  });
+
+  it("supports string-shaped attestation response (legacy)", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve("https://app.uniswap.org"), logError: noopLog },
+      "hash",
+      { name: "Uniswap", description: "", url: "https://app.uniswap.org", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("VALID");
+    expect(ctx.verified.origin).toBe("https://app.uniswap.org");
+  });
+
+  it("forwards verifyUrl from metadata to resolver", async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    await buildVerifyContext({ resolve: spy, logError: noopLog }, "h", {
+      name: "x",
+      description: "",
+      url: "https://x.com",
+      icons: [],
+      verifyUrl: "https://verify.example.com",
+    });
+    expect(spy).toHaveBeenCalledWith({
+      attestationId: "h",
+      verifyUrl: "https://verify.example.com",
+    });
+  });
+
+  it("regression: legitimate dApp must produce VALID when caller passes dApp metadata", async () => {
+    const dappMetadata = {
+      name: "Uniswap",
+      description: "",
+      url: "https://app.uniswap.org",
+      icons: [],
+    };
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://app.uniswap.org" }),
+        logError: noopLog,
+      },
+      "hash",
+      dappMetadata,
+    );
+    expect(ctx.verified.validation).toBe("VALID");
+  });
+
+  it("returns UNKNOWN with empty origin when metadata is undefined", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+    expect(ctx.verified.verifyUrl).toBe("");
+  });
+
+  it("returns UNKNOWN with empty origin when metadata is null", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      null as any,
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+  });
+
+  it("returns UNKNOWN with empty origin when metadata.url is empty string", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      { name: "x", description: "", url: "", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+  });
+
+  it("propagates isScam even when metadata is undefined", async () => {
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://attacker.com", isScam: true }),
+        logError: noopLog,
+      },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.isScam).toBe(true);
+  });
+
+  it("flags empty-url dApp as INVALID when Reown returns an attested origin", async () => {
+    // Spoof scenario: attacker sets name="Uniswap" but omits url so the legacy
+    // null-guard skipped validation entirely. Receiving an attested origin
+    // means Reown knows the real source — surface it as INVALID.
+    const ctx = await buildVerifyContext(
+      {
+        resolve: () => Promise.resolve({ origin: "https://evil.com" }),
+        logError: noopLog,
+      },
+      "hash",
+      { name: "Uniswap", description: "", url: "", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://evil.com");
+  });
+
+  it("flags empty-url dApp as INVALID when attestation is a bare string origin", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve("https://evil.com"), logError: noopLog },
+      "hash",
+      undefined as any,
+    );
+    expect(ctx.verified.validation).toBe("INVALID");
+    expect(ctx.verified.origin).toBe("https://evil.com");
+  });
+
+  it("keeps UNKNOWN when metadata.url is empty and attestation has no origin", async () => {
+    const ctx = await buildVerifyContext(
+      { resolve: () => Promise.resolve(undefined), logError: noopLog },
+      "hash",
+      { name: "x", description: "", url: "", icons: [] },
+    );
+    expect(ctx.verified.validation).toBe("UNKNOWN");
+    expect(ctx.verified.origin).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Mirror the `getVerifyContext` activation from `ExodusForks/walletconnect-monorepo` in `auth-client/src/controllers/engine.ts`, so auth_request flows populate `verifyContext.verified.{origin, validation, isScam}` from `core.verify.resolve` instead of always returning `validation: "UNKNOWN"`.

## Dependency

Requires `ExodusForks/walletconnect-monorepo#24` (which re-enables `core.verify.resolve`) to be published first; otherwise `resolve` still throws.

## Test plan

- No existing test asserts on `verified.validation` content
- Existing assertions of `validation === "UNKNOWN"` still hold (test attestations 404 -> caught -> `UNKNOWN`)
